### PR TITLE
chore: change privacy link and text

### DIFF
--- a/teammapper-frontend/src/app/modules/application/components/dialog-about/dialog-about.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/dialog-about/dialog-about.component.html
@@ -13,7 +13,7 @@
       GitHub
     </a>
     · <a href="https://kits.blog/impressum/" target="_blank">Impressum</a> ·
-    <a href="https://kits.blog/datenschutzerklaerung/" target="_blank"
+    <a href="https://kits.blog/datenschutz/#teammapper" target="_blank"
       >Datenschutz</a
     >
   </div>

--- a/teammapper-frontend/src/app/modules/start/start.component.html
+++ b/teammapper-frontend/src/app/modules/start/start.component.html
@@ -21,7 +21,7 @@
         >
         <a
           class="padding-8 font-white"
-          href="https://kits.blog/datenschutzerklaerung/"
+          href="https://kits.blog/datenschutz/#teammapper"
           >Datenschutz</a
         >
       </div>
@@ -86,7 +86,7 @@
         Dieses Tool darf nur in Bildungskontexten genutzt werden. Die Eingabe
         personenbezogener Daten ist zu vermeiden.
         <br /><br />
-        Achtung: Mindmaps werden 13 Monate nach der letzten Bearbeitung gelöscht.
+        Achtung: Mindmaps werden 24 Monate nach der letzten Bearbeitung gelöscht.
       </small>
     </div>
   </div>
@@ -106,7 +106,7 @@
         >
         <a
           class="padding-8 font-white"
-          href="https://kits.blog/datenschutzerklaerung/"
+          href="https://kits.blog/datenschutz/#teammapper"
           >Datenschutz</a
         >
       </div>


### PR DESCRIPTION
This PR updates the landinpage to the new privacy link. It also changes the text that the maps are now stored for to 24 months.